### PR TITLE
Fix ratio scrape and harden the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Dependencies
 node_modules/
+venv/
+.venv/
+__pycache__/
+*.pyc
 .env
 .env.local
 .env.development.local
@@ -20,6 +24,8 @@ yarn-error.log*
 # OS generated files
 .DS_Store
 .DS_Store?
+Icon
+Icon?
 ._*
 .Spotlight-V100
 .Trashes

--- a/functions/indexswapy.js
+++ b/functions/indexswapy.js
@@ -1,192 +1,335 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
 
-// Cache for the ratios - start empty
+const RATIO_SOURCE_URL = 'https://spyconverter.com/converter.html';
+const FETCH_INTERVAL_MS = 15 * 60 * 1000;
+const MAX_SCRAPE_BYTES = 512 * 1024;
+const SCRAPE_TIMEOUT_MS = 8000;
+const MAX_POST_BYTES = 4096;
+const MAX_CONVERSION_VALUE = 1_000_000;
+const MIN_RATIO = 0.5;
+const MAX_RATIO = 500;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX = 60;
+const RATE_LIMIT_MAX_KEYS = 5000;
+
+const ALLOWED_ORIGINS = new Set([
+    'https://indexswapy.netlify.app',
+    'http://localhost:3000',
+    'http://localhost:5000',
+    'http://localhost:5500',
+    'http://localhost:8080',
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:5000',
+    'http://127.0.0.1:5500',
+    'http://127.0.0.1:8080',
+]);
+
+const CONVERSIONS = {
+    qqq_to_ndx: (value, ratios) => value * ratios['NDX/QQQ Ratio'],
+    qqq_to_nq: (value, ratios) => value * ratios['NQ/QQQ Ratio'],
+    nq_to_qqq: (value, ratios) => value / ratios['NQ/QQQ Ratio'],
+    ndx_to_qqq: (value, ratios) => value / ratios['NDX/QQQ Ratio'],
+    es_to_spy: (value, ratios) => value / ratios['ES/SPY Ratio'],
+    spy_to_es: (value, ratios) => value * ratios['ES/SPY Ratio'],
+};
+
+const RATIO_PATTERNS = {
+    'ES/SPY Ratio': /let es_spy_ratio\s*=(?:\s|\/\*[\s\S]*?\*\/)*(\d+(?:\.\d+)?)\s*;/,
+    'NQ/QQQ Ratio': /let nq_qqq_ratio\s*=(?:\s|\/\*[\s\S]*?\*\/)*(\d+(?:\.\d+)?)\s*;/,
+    'NDX/QQQ Ratio': /let ndx_qqq_ratio\s*=(?:\s|\/\*[\s\S]*?\*\/)*(\d+(?:\.\d+)?)\s*;/,
+};
+
 let cachedRatios = null;
 let lastFetchTime = 0;
-const FETCH_INTERVAL = 15 * 60 * 1000; // 15 minutes in milliseconds
+let inFlightFetch = null;
+const rateLimitHits = new Map();
 
-async function fetchLatestRatios() {
+function header(headers, name) {
+    if (!headers) return undefined;
+    const lower = name.toLowerCase();
+    const key = Object.keys(headers).find((k) => k.toLowerCase() === lower);
+    return key ? headers[key] : undefined;
+}
+
+function clientIp(event) {
+    const netlifyIp = header(event.headers, 'x-nf-client-connection-ip');
+    if (netlifyIp) return String(netlifyIp).split(',')[0].trim();
+    const forwarded = header(event.headers, 'x-forwarded-for');
+    if (forwarded) return String(forwarded).split(',')[0].trim();
+    return 'unknown';
+}
+
+function pruneRateLimits(now) {
+    if (rateLimitHits.size < RATE_LIMIT_MAX_KEYS) {
+        for (const [ip, rec] of rateLimitHits) {
+            if (now - rec.start > RATE_LIMIT_WINDOW_MS) rateLimitHits.delete(ip);
+        }
+        return;
+    }
+    rateLimitHits.clear();
+}
+
+function isRateLimited(ip) {
+    const now = Date.now();
+    pruneRateLimits(now);
+    const rec = rateLimitHits.get(ip);
+    if (!rec || now - rec.start > RATE_LIMIT_WINDOW_MS) {
+        rateLimitHits.set(ip, { count: 1, start: now });
+        return false;
+    }
+    rec.count += 1;
+    return rec.count > RATE_LIMIT_MAX;
+}
+
+function isAllowedOrigin(origin) {
+    if (!origin) return false;
+    if (ALLOWED_ORIGINS.has(origin)) return true;
     try {
-        const response = await axios.get('https://spyconverter.com/converter.html');
-        const $ = cheerio.load(response.data);
-        
-        // Find all script tags and look for the one containing the ratios
-        const scripts = $('script').toArray();
-        let scriptContent = '';
-        
-        for (const script of scripts) {
-            const content = $(script).text();
-            if (content.includes('es_spy_ratio') && 
-                content.includes('nq_qqq_ratio') && 
-                content.includes('ndx_qqq_ratio')) {
-                scriptContent = content;
-                break;
-            }
-        }
-
-        if (!scriptContent) {
-            throw new Error('Could not find script containing ratios');
-        }
-
-        // Extract ratios using regex
-        const es_spy_ratio = scriptContent.match(/let es_spy_ratio = ([\d.]+);/)[1];
-        const nq_qqq_ratio = scriptContent.match(/let nq_qqq_ratio = ([\d.]+);/)[1];
-        const ndx_qqq_ratio = scriptContent.match(/let ndx_qqq_ratio = ([\d.]+);/)[1];
-
-        // Update cached ratios
-        cachedRatios = {
-            "NDX/QQQ Ratio": parseFloat(ndx_qqq_ratio),
-            "NQ/QQQ Ratio": parseFloat(nq_qqq_ratio),
-            "ES/SPY Ratio": parseFloat(es_spy_ratio)
-        };
-
-        lastFetchTime = Date.now();
-        console.log('Ratios updated:', cachedRatios);
-    } catch (error) {
-        console.error('Error fetching ratios:', error);
-        if (!cachedRatios) {
-            // If we have no cached data, throw the error
-            throw error;
-        }
-        // Otherwise, keep using cached values if fetch fails
+        const url = new URL(origin);
+        return url.protocol === 'http:' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1');
+    } catch {
+        return false;
     }
 }
 
-// Initial fetch
-fetchLatestRatios().catch(error => {
-    console.error('Initial fetch failed:', error);
-});
-
-// Set up periodic fetching
-setInterval(fetchLatestRatios, FETCH_INTERVAL);
-
-exports.handler = async (event, context) => {
-    // Set CORS headers
+function corsHeaders(event) {
+    const origin = header(event.headers, 'origin');
+    const allowed = isAllowedOrigin(origin) ? origin : null;
     const headers = {
-        'Access-Control-Allow-Origin': 'https://indexswapy.netlify.app',
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+        'Referrer-Policy': 'no-referrer',
+        'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'",
+        'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+        'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
         'Access-Control-Allow-Headers': 'Content-Type',
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        Vary: 'Origin',
     };
-
-    // Handle preflight requests
-    if (event.httpMethod === 'OPTIONS') {
-        return {
-            statusCode: 200,
-            headers,
-            body: '',
-        };
+    if (allowed) {
+        headers['Access-Control-Allow-Origin'] = allowed;
     }
+    return headers;
+}
 
-    // Fetch latest ratios on every request
-    try {
-        await fetchLatestRatios();
-    } catch (error) {
-        if (!cachedRatios) {
-            // If we have no cached data, return an error
-            return {
-                statusCode: 503,
-                headers,
-                body: JSON.stringify({
-                    status: 'error',
-                    message: 'Service temporarily unavailable - unable to fetch ratios'
-                }),
-            };
-        }
-        // Otherwise, continue with cached values
-    }
-
-    // Get the path
-    const path = event.path.replace('/.netlify/functions/indexswapy', '');
-
-    // Handle conversion requests
-    if (event.httpMethod === 'POST') {
-        try {
-            const body = JSON.parse(event.body);
-            const { type, value } = body;
-
-            if (!type || !value) {
-                return {
-                    statusCode: 400,
-                    headers,
-                    body: JSON.stringify({
-                        status: 'error',
-                        message: 'Missing type or value'
-                    }),
-                };
-            }
-
-            let result;
-            switch (type) {
-                case 'qqq_to_ndx':
-                    result = value * cachedRatios["NDX/QQQ Ratio"];
-                    break;
-                case 'qqq_to_nq':
-                    result = value * cachedRatios["NQ/QQQ Ratio"];
-                    break;
-                case 'nq_to_qqq':
-                    result = value / cachedRatios["NQ/QQQ Ratio"];
-                    break;
-                case 'ndx_to_qqq':
-                    result = value / cachedRatios["NDX/QQQ Ratio"];
-                    break;
-                case 'es_to_spy':
-                    result = value / cachedRatios["ES/SPY Ratio"];
-                    break;
-                case 'spy_to_es':
-                    result = value * cachedRatios["ES/SPY Ratio"];
-                    break;
-                default:
-                    return {
-                        statusCode: 400,
-                        headers,
-                        body: JSON.stringify({
-                            status: 'error',
-                            message: 'Invalid conversion type'
-                        }),
-                    };
-            }
-
-            return {
-                statusCode: 200,
-                headers,
-                body: JSON.stringify({
-                    status: 'ok',
-                    result: Number(result.toFixed(2))
-                }),
-            };
-        } catch (error) {
-            return {
-                statusCode: 400,
-                headers,
-                body: JSON.stringify({
-                    status: 'error',
-                    message: error.message
-                }),
-            };
-        }
-    }
-
-    // Handle ratio endpoints
-    if (path === '/ratios' || path === '/api/ratios' || path === '/data') {
-        return {
-            statusCode: 200,
-            headers,
-            body: JSON.stringify({
-                status: 'ok',
-                timestamp: new Date().toISOString(),
-                ratios: cachedRatios
-            }),
-        };
-    }
-
-    // Handle 404
+function json(event, statusCode, payload, extraHeaders) {
     return {
-        statusCode: 404,
-        headers,
-        body: JSON.stringify({
-            status: 'error',
-            message: 'Endpoint not found'
-        }),
+        statusCode,
+        headers: { ...corsHeaders(event), ...(extraHeaders || {}) },
+        body: JSON.stringify(payload),
     };
-}; 
+}
+
+function parseRatio(scriptContent, label, pattern) {
+    const match = scriptContent.match(pattern);
+    if (!match) {
+        throw new Error(`Missing ${label}`);
+    }
+    const value = Number(match[1]);
+    if (!Number.isFinite(value) || value < MIN_RATIO || value > MAX_RATIO) {
+        throw new Error(`Invalid ${label}`);
+    }
+    return value;
+}
+
+async function scrapeRatios() {
+    const response = await axios.get(RATIO_SOURCE_URL, {
+        timeout: SCRAPE_TIMEOUT_MS,
+        maxRedirects: 3,
+        maxContentLength: MAX_SCRAPE_BYTES,
+        maxBodyLength: MAX_SCRAPE_BYTES,
+        responseType: 'text',
+        transitional: { clarifyTimeoutError: true },
+        validateStatus: (status) => status === 200,
+        headers: {
+            Accept: 'text/html',
+            'Accept-Language': 'en',
+        },
+    });
+
+    const $ = cheerio.load(String(response.data || ''), { xmlMode: false });
+    let scriptContent = '';
+    for (const script of $('script').toArray()) {
+        const content = $(script).text();
+        if (
+            content.includes('es_spy_ratio') &&
+            content.includes('nq_qqq_ratio') &&
+            content.includes('ndx_qqq_ratio')
+        ) {
+            scriptContent = content;
+            break;
+        }
+    }
+    if (!scriptContent) {
+        throw new Error('Ratio script not found');
+    }
+
+    return {
+        'NDX/QQQ Ratio': parseRatio(scriptContent, 'NDX/QQQ Ratio', RATIO_PATTERNS['NDX/QQQ Ratio']),
+        'NQ/QQQ Ratio': parseRatio(scriptContent, 'NQ/QQQ Ratio', RATIO_PATTERNS['NQ/QQQ Ratio']),
+        'ES/SPY Ratio': parseRatio(scriptContent, 'ES/SPY Ratio', RATIO_PATTERNS['ES/SPY Ratio']),
+    };
+}
+
+async function getRatios() {
+    const now = Date.now();
+    if (cachedRatios && now - lastFetchTime < FETCH_INTERVAL_MS) {
+        return cachedRatios;
+    }
+    if (!inFlightFetch) {
+        inFlightFetch = scrapeRatios()
+            .then((ratios) => {
+                cachedRatios = ratios;
+                lastFetchTime = Date.now();
+                return cachedRatios;
+            })
+            .catch((error) => {
+                if (cachedRatios) {
+                    console.error('Using stale ratios after fetch failure');
+                    return cachedRatios;
+                }
+                throw error;
+            })
+            .finally(() => {
+                inFlightFetch = null;
+            });
+    }
+    return inFlightFetch;
+}
+
+function requestPath(event) {
+    const raw = String(event.path || '/');
+    const stripped = raw.replace(/^\/\.netlify\/functions\/indexswapy/, '') || '/';
+    const pathname = stripped.split('?')[0];
+    return pathname.replace(/\/+$/, '') || '/';
+}
+
+function parseConversionBody(event) {
+    const contentType = String(header(event.headers, 'content-type') || '');
+    if (!contentType.toLowerCase().includes('application/json')) {
+        throw Object.assign(new Error('Unsupported content type'), { statusCode: 415 });
+    }
+
+    if (event.body == null) {
+        throw Object.assign(new Error('Missing request body'), { statusCode: 400 });
+    }
+
+    const rawBody = typeof event.body === 'string'
+        ? event.body
+        : JSON.stringify(event.body);
+    if (Buffer.byteLength(rawBody, 'utf8') > MAX_POST_BYTES) {
+        throw Object.assign(new Error('Payload too large'), { statusCode: 413 });
+    }
+
+    let parsed;
+    try {
+        parsed = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
+    } catch {
+        throw Object.assign(new Error('Invalid JSON'), { statusCode: 400 });
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw Object.assign(new Error('Invalid request body'), { statusCode: 400 });
+    }
+
+    const { type, value } = parsed;
+    if (typeof type !== 'string' || !Object.prototype.hasOwnProperty.call(CONVERSIONS, type)) {
+        throw Object.assign(new Error('Invalid conversion type'), { statusCode: 400 });
+    }
+
+    const numeric = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+    if (!Number.isFinite(numeric) || numeric < 0 || numeric > MAX_CONVERSION_VALUE) {
+        throw Object.assign(new Error('Invalid value'), { statusCode: 400 });
+    }
+
+    return { type, value: numeric };
+}
+
+exports._internal = {
+    parseConversionBody,
+    parseRatio,
+    requestPath,
+    corsHeaders,
+    RATIO_PATTERNS,
+    resetState() {
+        cachedRatios = null;
+        lastFetchTime = 0;
+        inFlightFetch = null;
+        rateLimitHits.clear();
+    },
+    setCache(ratios, fetchedAt) {
+        cachedRatios = ratios;
+        lastFetchTime = fetchedAt || Date.now();
+    },
+};
+
+exports.handler = async (event) => {
+    const method = String(event.httpMethod || 'GET').toUpperCase();
+
+    if (method === 'OPTIONS') {
+        return { statusCode: 204, headers: corsHeaders(event), body: '' };
+    }
+
+    if (method !== 'GET' && method !== 'POST') {
+        return json(event, 405, { status: 'error', message: 'Method not allowed' }, { Allow: 'GET, POST, OPTIONS' });
+    }
+
+    if (isRateLimited(clientIp(event))) {
+        return json(event, 429, { status: 'error', message: 'Too many requests' }, { 'Retry-After': '60' });
+    }
+
+    if (method === 'POST') {
+        let parsed;
+        try {
+            parsed = parseConversionBody(event);
+        } catch (error) {
+            const statusCode = error.statusCode || 400;
+            return json(event, statusCode, {
+                status: 'error',
+                message: error.statusCode ? error.message : 'Invalid request',
+            });
+        }
+
+        try {
+            const ratios = await getRatios();
+            const result = CONVERSIONS[parsed.type](parsed.value, ratios);
+            if (!Number.isFinite(result)) {
+                return json(event, 500, { status: 'error', message: 'Conversion failed' });
+            }
+            return json(event, 200, {
+                status: 'ok',
+                result: Number(result.toFixed(2)),
+            });
+        } catch (error) {
+            console.error('Unable to load ratios:', error && error.message);
+            return json(event, 503, {
+                status: 'error',
+                message: 'Service temporarily unavailable',
+            });
+        }
+    }
+
+    const path = requestPath(event);
+    if (path !== '/ratios' && path !== '/api/ratios' && path !== '/data' && path !== '/') {
+        return json(event, 404, { status: 'error', message: 'Endpoint not found' });
+    }
+
+    try {
+        const ratios = await getRatios();
+        return json(event, 200, {
+            status: 'ok',
+            timestamp: new Date().toISOString(),
+            ratios,
+            ...(path === '/' ? { endpoints: ['/ratios', '/api/ratios', '/data'] } : {}),
+        });
+    } catch (error) {
+        console.error('Unable to load ratios:', error && error.message);
+        return json(event, 503, {
+            status: 'error',
+            message: 'Service temporarily unavailable',
+        });
+    }
+};

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,17 @@
 [build]
   functions = "functions"
   command = ""
-  publish = ""
+  publish = "public"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "no-referrer"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Content-Security-Policy = "default-src 'none'; frame-ancestors 'none'"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
 
 [[redirects]]
   from = "/api/*"
@@ -21,4 +31,4 @@
 [[redirects]]
   from = "/*"
   to = "/.netlify/functions/indexswapy/:splat"
-  status = 200 
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   functions = "functions"
   command = ""
-  publish = "public"
+  publish = ""
 
 [[headers]]
   for = "/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,50 +1,27 @@
 {
   "name": "indexswapy-backend",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "indexswapy-backend",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
-        "@netlify/functions": "^2.0.0",
-        "axios": "^1.6.7",
-        "cheerio": "^1.0.0-rc.12"
+        "axios": "^1.19.0",
+        "cheerio": "^1.0.0"
       }
     },
-    "node_modules/@netlify/functions": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.8.2.tgz",
-      "integrity": "sha512-DeoAQh8LuNPvBE4qsKlezjKj0PyXDryOFJfJKo3Z1qZLKzQ21sT314KQKPVjfvw6knqijj+IO+0kHXy/TJiqNA==",
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/serverless-functions-api": "1.26.1"
+        "debug": "4"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@netlify/node-cookies": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/node-cookies/-/node-cookies-0.1.0.tgz",
-      "integrity": "sha512-OAs1xG+FfLX0LoRASpqzVntVV/RpYkgpI0VrUnw2u0Q1qiZUzcPffxRK8HF3gc4GjuhG5ahOEMJ9bswBiZPq0g==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.16.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@netlify/serverless-functions-api": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.26.1.tgz",
-      "integrity": "sha512-q3L9i3HoNfz0SGpTIS4zTcKBbRkxzCRpd169eyiTuk3IwcPC3/85mzLHranlKo2b+HYT0gu37YxGB45aD8A3Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@netlify/node-cookies": "^0.1.0",
-        "urlpattern-polyfill": "8.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -54,14 +31,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/boolbase": {
@@ -163,6 +141,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/delayed-stream": {
@@ -287,9 +282,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -314,9 +309,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -334,15 +329,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -434,9 +430,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -462,6 +458,19 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.1.0",
         "entities": "^4.5.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -505,6 +514,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -556,10 +571,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -568,19 +586,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
-    },
-    "node_modules/urlpattern-polyfill": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
-      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
-      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "indexswapy-backend",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Index conversion API",
   "main": "functions/indexswapy.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/test-api.js",
     "start": "node test-server.js"
   },
   "dependencies": {
-    "@netlify/functions": "^2.0.0",
-    "axios": "^1.6.7",
-    "cheerio": "^1.0.0-rc.12"
+    "axios": "^1.19.0",
+    "cheerio": "^1.0.0"
+  },
+  "overrides": {
+    "undici": "^6.28.0"
   }
 } 

--- a/test-server.js
+++ b/test-server.js
@@ -1,33 +1,83 @@
 const http = require('http');
 const { handler } = require('./functions/indexswapy');
 
-const server = http.createServer(async (req, res) => {
-    // Convert Node.js request to Netlify Function event format
-    const event = {
-        httpMethod: req.method,
-        path: req.url,
-        headers: req.headers
-    };
+const PORT = 8888;
+const HOST = '127.0.0.1';
+const MAX_BODY_BYTES = 4096;
 
-    // Call our function
-    const result = await handler(event);
+function sendJson(res, statusCode, payload) {
+    if (res.headersSent) return;
+    res.statusCode = statusCode;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify(payload));
+}
 
-    // Set headers
-    Object.entries(result.headers || {}).forEach(([key, value]) => {
-        res.setHeader(key, value);
+function readBody(req) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        let size = 0;
+        let rejected = false;
+        req.on('data', (chunk) => {
+            size += chunk.length;
+            if (size > MAX_BODY_BYTES && !rejected) {
+                rejected = true;
+                const error = new Error('Payload too large');
+                error.statusCode = 413;
+                reject(error);
+                req.resume();
+                return;
+            }
+            if (!rejected) chunks.push(chunk);
+        });
+        req.on('end', () => {
+            if (!rejected) resolve(Buffer.concat(chunks).toString('utf8'));
+        });
+        req.on('error', reject);
     });
+}
 
-    // Send response
-    res.statusCode = result.statusCode;
-    res.end(result.body);
+const server = http.createServer(async (req, res) => {
+    try {
+        const declaredLength = Number(req.headers['content-length']);
+        if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+            sendJson(res, 413, { status: 'error', message: 'Payload too large' });
+            req.resume();
+            return;
+        }
+
+        const body = req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH'
+            ? await readBody(req)
+            : undefined;
+
+        const event = {
+            httpMethod: req.method,
+            path: req.url,
+            headers: {
+                ...req.headers,
+                'x-forwarded-for': req.socket.remoteAddress,
+            },
+            body,
+        };
+
+        const result = await handler(event);
+        Object.entries(result.headers || {}).forEach(([key, value]) => {
+            res.setHeader(key, value);
+        });
+        res.statusCode = result.statusCode;
+        res.end(result.body || '');
+    } catch (error) {
+        sendJson(res, error.statusCode || 500, {
+            status: 'error',
+            message: error.statusCode === 413 ? 'Payload too large' : 'Internal server error',
+        });
+    }
 });
 
-const PORT = 8888;
-server.listen(PORT, () => {
-    console.log(`Server running at http://localhost:${PORT}`);
+server.listen(PORT, HOST, () => {
+    console.log(`Server running at http://${HOST}:${PORT}`);
     console.log('Test endpoints:');
-    console.log('http://localhost:8888/');
-    console.log('http://localhost:8888/api/ratios');
-    console.log('http://localhost:8888/ratios');
-    console.log('http://localhost:8888/data');
-}); 
+    console.log(`http://${HOST}:${PORT}/`);
+    console.log(`http://${HOST}:${PORT}/api/ratios`);
+    console.log(`http://${HOST}:${PORT}/ratios`);
+    console.log(`http://${HOST}:${PORT}/data`);
+});

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -1,0 +1,151 @@
+const assert = require('assert');
+const { handler, _internal } = require('../functions/indexswapy');
+
+const SAMPLE_SCRIPT = `
+    let es_spy_ratio = /* ES_SPY_RATIO */ 10.059244391207226;
+    let nq_qqq_ratio = /* NQ_QQQ_RATIO */ 41.24465000690322;
+    let ndx_qqq_ratio = /* NDX_QQQ_RATIO */ 41.10098439872981;
+`;
+
+const CACHED = {
+    'NDX/QQQ Ratio': 40,
+    'NQ/QQQ Ratio': 41,
+    'ES/SPY Ratio': 10,
+};
+
+function event(overrides) {
+    return {
+        httpMethod: 'GET',
+        path: '/ratios',
+        headers: {},
+        ...overrides,
+    };
+}
+
+async function run() {
+    _internal.resetState();
+
+    assert.strictEqual(
+        _internal.parseRatio(SAMPLE_SCRIPT, 'ES/SPY Ratio', _internal.RATIO_PATTERNS['ES/SPY Ratio']),
+        10.059244391207226
+    );
+    assert.strictEqual(
+        _internal.parseRatio(SAMPLE_SCRIPT, 'NQ/QQQ Ratio', _internal.RATIO_PATTERNS['NQ/QQQ Ratio']),
+        41.24465000690322
+    );
+    assert.strictEqual(
+        _internal.parseRatio(SAMPLE_SCRIPT, 'NDX/QQQ Ratio', _internal.RATIO_PATTERNS['NDX/QQQ Ratio']),
+        41.10098439872981
+    );
+
+    assert.throws(() => {
+        _internal.parseRatio('let es_spy_ratio = 9999;', 'ES/SPY Ratio', _internal.RATIO_PATTERNS['ES/SPY Ratio']);
+    }, /Invalid/);
+
+    assert.strictEqual(_internal.requestPath({ path: '/.netlify/functions/indexswapy/api/ratios' }), '/api/ratios');
+    assert.strictEqual(_internal.requestPath({ path: '/ratios?x=1' }), '/ratios');
+    assert.strictEqual(_internal.requestPath({ path: '/.netlify/functions/indexswapy/' }), '/');
+
+    const allowed = _internal.corsHeaders({ headers: { origin: 'https://indexswapy.netlify.app' } });
+    assert.strictEqual(allowed['Access-Control-Allow-Origin'], 'https://indexswapy.netlify.app');
+    const local = _internal.corsHeaders({ headers: { origin: 'http://localhost:60257' } });
+    assert.strictEqual(local['Access-Control-Allow-Origin'], 'http://localhost:60257');
+    const denied = _internal.corsHeaders({ headers: { origin: 'https://evil.example' } });
+    assert.strictEqual(denied['Access-Control-Allow-Origin'], undefined);
+    assert.ok(denied['X-Content-Type-Options']);
+
+    const parsed = _internal.parseConversionBody({
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ type: 'qqq_to_ndx', value: 400 }),
+    });
+    assert.deepStrictEqual(parsed, { type: 'qqq_to_ndx', value: 400 });
+
+    assert.throws(() => {
+        _internal.parseConversionBody({
+            headers: { 'content-type': 'text/plain' },
+            body: '{}',
+        });
+    }, (err) => err.statusCode === 415);
+
+    assert.throws(() => {
+        _internal.parseConversionBody({
+            headers: { 'content-type': 'application/json' },
+            body: '{not json',
+        });
+    }, (err) => err.statusCode === 400 && err.message === 'Invalid JSON');
+
+    assert.throws(() => {
+        _internal.parseConversionBody({
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ type: 'hack', value: 1 }),
+        });
+    }, (err) => err.statusCode === 400);
+
+    assert.throws(() => {
+        _internal.parseConversionBody({
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ type: 'qqq_to_ndx', value: -1 }),
+        });
+    }, (err) => err.statusCode === 400);
+
+    assert.throws(() => {
+        _internal.parseConversionBody({
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ type: 'qqq_to_ndx', value: 9_999_999 }),
+        });
+    }, (err) => err.statusCode === 400);
+
+    _internal.setCache(CACHED, Date.now());
+
+    const options = await handler(event({ httpMethod: 'OPTIONS' }));
+    assert.strictEqual(options.statusCode, 204);
+
+    const put = await handler(event({ httpMethod: 'PUT' }));
+    assert.strictEqual(put.statusCode, 405);
+
+    const missing = await handler(event({ path: '/nope' }));
+    assert.strictEqual(missing.statusCode, 404);
+
+    const ratios = await handler(event({ path: '/api/ratios' }));
+    assert.strictEqual(ratios.statusCode, 200);
+    const ratioBody = JSON.parse(ratios.body);
+    assert.strictEqual(ratioBody.status, 'ok');
+    assert.strictEqual(ratioBody.ratios['NDX/QQQ Ratio'], 40);
+
+    const converted = await handler(event({
+        httpMethod: 'POST',
+        path: '/',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ type: 'qqq_to_ndx', value: 400 }),
+    }));
+    assert.strictEqual(converted.statusCode, 200);
+    assert.strictEqual(JSON.parse(converted.body).result, 16000);
+
+    const badPost = await handler(event({
+        httpMethod: 'POST',
+        path: '/',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ type: 'hack', value: 1 }),
+    }));
+    assert.strictEqual(badPost.statusCode, 400);
+    assert.ok(!/stack|SyntaxError/i.test(badPost.body));
+
+    _internal.resetState();
+    _internal.setCache(CACHED, Date.now());
+    let limited = 0;
+    for (let i = 0; i < 65; i += 1) {
+        const res = await handler(event({
+            path: '/ratios',
+            headers: { 'x-nf-client-connection-ip': '203.0.113.9' },
+        }));
+        if (res.statusCode === 429) limited += 1;
+    }
+    assert.ok(limited >= 5, `expected rate limit 429s, got ${limited}`);
+
+    console.log('backend tests passed');
+}
+
+run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Parse the current spyconverter ratio format (comments between `=` and the number) so `/api/ratios` stops returning 503.
- Honor the 15-minute cache, validate POST bodies, add rate limits and security headers.

## Test plan
- [ ] Deploy preview or merge and hit `/.netlify/functions/indexswapy/api/ratios`
- [ ] Confirm JSON `status: ok` and three finite ratios
- [ ] Confirm frontend conversions work against the live backend